### PR TITLE
Fix: Add missing port exposure in Docker Compose example within README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ services:
       - PG_USER=<root-user>
       - PG_PASSWORD=<root-password>
       - PG_DB_NAME=rachoon
+    port:
+      - 8080:8080
 
   gotenberg:
     image: gotenberg/gotenberg:8


### PR DESCRIPTION
The Docker Compose guide previously lacked the exposed port mapping, which could cause confusion when running the service. This update adds the correct ports section to ensure users can access the application as intended.
