### PR TITLE
fix: exclude paid/draft invoices from overdue calculation

### DIFF
--- a/apps/backend/app/Controllers/Http/DashboardController.ts
+++ b/apps/backend/app/Controllers/Http/DashboardController.ts
@@ -71,11 +71,26 @@ export default class DashboardController {
       .select(Database.raw(`sum((data->>'net')::float) as net`))
       .first()
 
+    const overdueAmounts = await Document.query()
+      .where({
+        type: DocumentType.Invoice,
+        organizationId: ctx.auth.user?.organization.id,
+        status: DocumentStatus.Pending,
+      })
+      .whereRaw(`(data->>'dueDate')::timestamp < now()`)
+      .select(Database.raw(`sum((data->>'total')::float) as total`))
+      .select(Database.raw(`sum((data->>'net')::float) as net`))
+      .first()
+
     return {
       invoices: {
         net: invoiceAmounts?.$extras.net,
         total: invoiceAmounts?.$extras.total,
         pending: pendingInvoices,
+        overdue: {
+          net: overdueAmounts?.$extras.net || 0,
+          total: overdueAmounts?.$extras.total || 0,
+        },
       },
       reminders: {
         pending: pendingReminders,

--- a/apps/backend/app/Models/Document.ts
+++ b/apps/backend/app/Models/Document.ts
@@ -38,7 +38,11 @@ export default class Document extends BaseAppModel {
 
   @computed()
   public get overdue() {
-    return isPast(this.data.dueDate)
+    return (
+      this.status !== DocumentStatus.Paid &&
+      this.status !== DocumentStatus.Draft &&
+      isPast(this.data.dueDate)
+    )
   }
 
   @computed()

--- a/apps/frontend/models/dashboard.ts
+++ b/apps/frontend/models/dashboard.ts
@@ -6,6 +6,10 @@ class Dashboard {
     net: 0,
     total: 0,
     pending: [] as Document[],
+    overdue: {
+      net: 0,
+      total: 0,
+    },
   };
   offers = {
     net: 0,

--- a/apps/frontend/pages/index.vue
+++ b/apps/frontend/pages/index.vue
@@ -53,11 +53,11 @@ useDashboard().get();
           </div>
           <div class="stat-title text-error">Invoices overdue</div>
           <div class="stat-value">
-            {{ useFormat.toCurrency(useDashboard().dashboard.invoices.total) }}
+            {{ useFormat.toCurrency(useDashboard().dashboard.invoices.overdue.total) }}
           </div>
           <div class="stat-desc">
             net
-            {{ useFormat.toCurrency(useDashboard().dashboard.invoices.net) }}
+            {{ useFormat.toCurrency(useDashboard().dashboard.invoices.overdue.net) }}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Fixes #64 — Paid invoices were incorrectly appearing in both the "paid" and "overdue" totals on the overview dashboard.

**Root cause:** Three interrelated issues:

1. **Backend `Document` model** (`apps/backend/app/Models/Document.ts`): The `overdue` computed property only checked `isPast(this.data.dueDate)` without considering the document's status. Any invoice with a past due date was flagged as overdue, even if already paid or still in draft.

2. **Backend `DashboardController`** (`apps/backend/app/Controllers/Http/DashboardController.ts`): No separate query existed for overdue invoice amounts. The dashboard API had no overdue data at all.

3. **Frontend `index.vue`** (`apps/frontend/pages/index.vue`): The "Invoices overdue" stat card displayed `dashboard.invoices.total` / `dashboard.invoices.net` — the exact same values as the "Invoices paid" card, which is why both cards always showed identical amounts.

**Changes:**

- **Document model**: `overdue` computed property now returns `false` for invoices with `Paid` or `Draft` status
- **DashboardController**: Added a new query for overdue amounts — invoices with `Pending` status AND a past due date
- **Frontend dashboard model**: Added `overdue` nested object (`net`/`total`) to the invoices data structure
- **Frontend index page**: "Invoices overdue" card now reads from `dashboard.invoices.overdue.total` / `.net`

## Test plan

- [ ] Create an invoice with a future due date
- [ ] Mark the invoice as paid
- [ ] Verify the dashboard shows the amount under "Invoices paid" only, NOT under "Invoices overdue"
- [ ] Create a pending invoice with a past due date
- [ ] Verify it appears under "Invoices overdue" but NOT under "Invoices paid"
- [ ] Verify document list view shows correct overdue badge only for non-paid, non-draft invoices with past due dates